### PR TITLE
Place configuration file in a project directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,16 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "assert_cli"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +155,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "bitflags"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "block-buffer"
@@ -290,6 +310,11 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cookie"
@@ -540,6 +565,26 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "directories"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1873,6 +1918,16 @@ version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "redox_users"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "getrandom 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,6 +2029,7 @@ dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "custom_error 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "directories 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "emailmessage 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "flexi_logger 0.14.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2009,6 +2065,17 @@ dependencies = [
  "derive_builder 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-xml 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2977,6 +3044,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
+"checksum arrayref 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+"checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum assert_cli 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a29ab7c0ed62970beb0534d637a8688842506d0ff9157de83286dacd065c8149"
 "checksum async-std 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0bf6039b315300e057d198b9d3ab92ee029e31c759b7f1afae538145e6f18a3e"
 "checksum async-task 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de6bd58f7b9cc49032559422595c81cbfcf04db2f2133592f70af19e258a1ced"
@@ -2988,6 +3057,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+"checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
@@ -3006,6 +3076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cdb90b60f2927f8d76139c72dbde7e10c3a2bc47c8594c9c7a66529f2687c03"
+"checksum constant_time_eq 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
@@ -3032,6 +3103,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum deunicode 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "850878694b7933ca4c9569d30a34b55031b9b139ee1fc7b94a527c4ef960d690"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+"checksum directories 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
+"checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum dtoa-short 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "59020b8513b76630c49d918c33db9f4c91638e7d3404a28084083b87e33f76f2"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
@@ -3185,6 +3258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
+"checksum redox_users 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
@@ -3194,6 +3268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rfc822_sanitizer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "680e8305c1e0cdf836dc4bec5424e045f278c975a3cac36d1ca01c4695f9d815"
 "checksum rgb 0.8.14 (registry+https://github.com/rust-lang/crates.io-index)" = "2089e4031214d129e201f8c3c8c2fe97cd7322478a0d1cdf78e7029b0042efdb"
 "checksum rss 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0706a43e890fbaf1714d495d12f69a7b34b70c6e903586d70311c2ce15ffe67"
+"checksum rust-argon2 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ custom_error = "1.7"
 async-std = "1.4"
 tokio = { version = "0.2", features = ["full"] }
 futures = "0.3"
+directories = "2.0"
 
 [dev-dependencies]
 assert_cli = "0.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,18 +31,24 @@
 //!
 //! #### `rrss2imap new`
 //!
-//! Creates a new `config.json` file. At init time, the config file will only contains `settings` element
-//! with the email address set. You **have** to set
+//! Creates a new `config.json` file in the configuration directory
+//! (`~/.config/rrss2imap/` on linux,
+//! `~/Library/Preferences/org.Rrss2imap.rrss2imap` on macOS,
+//! `AppData\Roaming\Rrss2imap\rrss2imap\` on Windows). At init time, the
+//! config file will only contains `settings` element with the email address
+//! set. You **have** to edit this file and set
 //!
 //! * the used imap server
 //! ** with user login and password
-//! ** and security settings (secure should contain `{"Yes": secure port}` for imap/s
-//! or `{"No": unsecure port}` for simple imap)
+//! ** and security settings (secure should contain `{"Yes": secure port}` for
+//!    imap/s or `{"No": unsecure port}` for simple imap)
 //! * the default config
-//! ** folder will be the full path to an imap folder where entries will fall in
+//! ** folder will be the *full path to an imap folder* where entries will
+//!    fall in (e.g., `INBOX.News`).  The exact syntax depends on your email provider.
 //! ** email will be the recipient email address (which may not be yours for easier filtering)
 //! ** Base64 image inlining
-//! * feeds is the list of all rss feeds that can be added
+//!
+//! `feeds` is the list of all rss feeds; use `rrss2imap add` to add a new feed.
 //!
 //! #### `rrss2imap add`
 //!
@@ -251,10 +257,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .format(flexi_logger::colored_detailed_format)
         .start()
         .unwrap_or_else(|e| panic!("Logger initialization failed with {}", e));
-    
+
     openssl_probe::init_ssl_cert_env_vars();
 
-    let store_result = store::Store::load();
+    let store_path = store::find_store();
+    let store_result = store::Store::load(&store_path);
     match store_result {
         Ok(mut store) => {
             let opt = RRSS2IMAP::from_args();
@@ -264,7 +271,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
                 RRSS2IMAP::List => store.list(),
 
-                RRSS2IMAP::Add { url, email, destination, inline_images, do_not_inline_images, parameters } => 
+                RRSS2IMAP::Add { url, email, destination, inline_images, do_not_inline_images, parameters } =>
                     store.add(url, email, destination, store.settings.config.inline(inline_images, do_not_inline_images), parameters),
                 RRSS2IMAP::Delete { feed } => store.delete(feed),
 
@@ -274,7 +281,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     let handle = tokio::spawn(async move {
                         store.run().await
                     });
-                
+
                     // Wait for the spawned task to finish
                     let _res = handle.await;
                 }
@@ -284,7 +291,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
         },
         Err(e) => {
-            error!("Impossible to open store {}\n{}", store::STORE, e);
+            error!("Impossible to open store {}\n{}", store_path.to_string_lossy(), e);
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,7 +285,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     match store_result {
         Ok(mut store) => {
             match opt.cmd {
-                Command::New { email } => store.set_email(email),
+                Command::New { email } => store.init_config(email),
                 Command::Email { email } => store.set_email(email),
 
                 Command::List => store.list(),

--- a/src/store.rs
+++ b/src/store.rs
@@ -97,6 +97,18 @@ impl Store {
             .unwrap_or_else(|_| panic!("Unable to write file {}", self.path.to_string_lossy()));
     }
 
+    /// Create a new configuration file with the given email.
+    pub fn init_config(&mut self, email: String) {
+        if self.path.exists() {
+            warn!("Config file {} already exists, leaving it unchanged.", self.path.to_string_lossy());
+        } else {
+            println!("Config file {} created, please edit it to finish configuration.", self.path.to_string_lossy());
+            self.settings.config.email = Some(email);
+            self.dirty = true;
+            self.save();
+        }
+    }
+
     /// Set a new value for email and save file (prior to obviously exiting)
     pub fn set_email(&mut self, email: String) {
         self.settings.config.email = Some(email);

--- a/src/store.rs
+++ b/src/store.rs
@@ -63,8 +63,8 @@ impl Store {
     /// Initialize a Store object from a config file at the given path. If the
     /// config file does not exist, return a Store object with default values.
     pub fn load(path: &PathBuf) -> Result<Store,UnusableStore> {
-        info!("Using store: {}", path.to_string_lossy());
         if path.exists() {
+            info!("Reading config file {}", path.to_string_lossy());
             // First read the file
             let mut file = File::open(path)?;
             let mut contents = String::new();
@@ -76,6 +76,7 @@ impl Store {
             // And return it
             return Ok(store);
         } else {
+            info!("Using fresh config file {}", path.to_string_lossy());
             return Ok(Store {
                 settings: Settings::default(),
                 feeds: vec![],
@@ -87,6 +88,7 @@ impl Store {
 
     /// Save all informations in the store file
     fn save(&self) {
+        info!("Saving config file {}", self.path.to_string_lossy());
         let serialized = serde_json::to_string_pretty(self).expect("Can't serialize Store to JSON");
         let directory = self.path.parent().unwrap_or(Path::new("."));
         fs::create_dir_all(directory)


### PR DESCRIPTION
- With this change, `rrss2imap` can find its configuration file no matter from
  which directory the user runs it.  Other utilities like `mu` that use a file
  to store persistent configuration do the same.

- If `config.json` is found in the current directory, use it.  This
  maintains backward compatibility for existing users.

- Use the `directories` crate to find a system-appropriate location when
  creating a fresh config file (e.g., `~/.config/rrss2imap/` on Linux).  Read
  the config file from that location unless it’s found in the current directory.

- There is arguably a regression introduced by this change -- after creating a
  new configuration, the user must immediately edit it, and the new location is
  not as convenient as the current directory.  It would be good to add more
  parameters to the `rrss2imap new` subcommand, so that it could generate a
  fully-functional configuration.