### PR TITLE
Honor config.email setting

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -82,10 +82,11 @@ impl Message {
         if date.is_err() {
             return Err(UnprocessableMessage::CantPutDateInMessage { value : self.date_text() });
         }
+        let to_addr = settings.config.email.as_ref().unwrap_or(&settings.email.user);
         let mut builder = Email::builder()
             .subject(&*self.title)
             .date(date.unwrap())
-            .to(settings.email.user.parse().unwrap())
+            .to(to_addr.parse().unwrap())
             ;
 
         match &feed.config.from {


### PR DESCRIPTION
- Use `config.email` setting for `To:` header; fall back to
  `settings.email.user` if `config.email` is not set.

- This makes a difference when the server login name is different from the
  user’s email address.