### PR TITLE
Add clippy action on pull requests

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -1,0 +1,17 @@
+on: pull_request
+name: Apply clippy comments to pull request
+jobs:
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          components: clippy
+          override: true
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}  
+          args: --all-features


### PR DESCRIPTION
Partially fixes #48 

Actually, this action won't create pull request to make improvements, but will comment all the changed files in any pull request that is made on your repository with improvements suggestions.

You can see the result on one of your file here : [Changed file on rrss2i ](https://github.com/grzi/rrss2imap/pull/2/files)

The action uses Github_token which is a default token in github action for this kind of interactions

However, please note the limitation here that would eventually be a problem : 

`Due to token permissions, this Action WILL NOT be able to post clippy annotations for Pull Requests from the forked repositories.`